### PR TITLE
Fix to use the non-JSON-model S3 API

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -7,6 +7,6 @@ echo
 read -p "Are you sure you want to create this deployment bucket: ${DeployBucket} (Y/n)?" yn
 case $yn in
   [Nn]* ) echo; echo "Okay, bucket creation aborted."; echo; exit;;
-  * ) echo "Creating bucket: ${DeployBucket}"; aws s3api create-bucket --region ${REGION} --bucket ${DeployBucket};echo;;
+  * ) echo "Creating bucket: ${DeployBucket}"; aws s3 mb s3://${DeployBucket} --region ${REGION};echo;;
 esac
 


### PR DESCRIPTION
Required for creating buckets in regions other than us-east-1, per Issue #8 .