### PR TITLE
fix: Fixed issue where accessing an inexistent file returned 503

### DIFF
--- a/src/GetOrCreateImage/GetOrCreateImage.js
+++ b/src/GetOrCreateImage/GetOrCreateImage.js
@@ -26,6 +26,7 @@ const GetOrCreateImage = async event => {
   } = event.Records[0]
 
   if (!['403', '404'].includes(status)) return response
+  if (!querystring) return response
 
   let { nextExtension, height, sourceImage, width } = parse(querystring)
   const [bucket] = domainName.match(/.+(?=\.s3\.amazonaws\.com)/i)


### PR DESCRIPTION
When file doesn't exist and S3 returns 403 in consequence, GetOrCreate lambda returns an error (cannot find method "replace" of undefined) and it causes a 503 Bad Gateway response.

This is because it tries to read from "sourceImage" which comes from querystring but querystring is actually undefined.